### PR TITLE
regex for bearer token not valid for gcp access token

### DIFF
--- a/internal/webserver/middleware/authorization.go
+++ b/internal/webserver/middleware/authorization.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	regexPatternForAuthHeader = "^(Bearer ([\\w-]*\\.[\\w-]*\\.[\\w-]*|[\\w-]*))$"
+	regexPatternForAuthHeader = "^(Bearer ([\\w-]*\\.[\\w-]*\\.[\\w-]*|[\\w-]*|[\\w-]*\\.[\\w-]*))$"
 )
 
 func CheckAuthorization(client client.Client, log logr.Logger, tls bool) mux.MiddlewareFunc {

--- a/internal/webserver/middleware/authorization_test.go
+++ b/internal/webserver/middleware/authorization_test.go
@@ -20,6 +20,7 @@ func TestCheckBearerToken(t *testing.T) {
 	}{
 		{"fail no bearer", "alksjdas239ldasdasd123ljksadsj", false, false},
 		{"pass jwt", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", true, false},
+		{"pass gcp access token", "Bearer ya29.A0AVA9y1tO6PluMRS3RY2zq2SjrZxHoMFgcuubgHq-yUNsoiFd8WkLiVHoxU_LtgbrHaYImH8qsM8IMvodoIFsW9gxVvPU8df6Hi7qKn76bem8ifDZ6VkSGl93nmDiDoVOEIBMEUeOgzxoUCwkLr2iFMvmtzzIhWnBpQqzkNnPtLXNGNFNGNFSDR65qe8oSrRP756QYC9GEAmbl8KRt0173", true, false},
 		{"pass webtoken", "Bearer alksjdas2_9ldas-dasd123ljksadsj", true, false},
 		{"fail space in token", "Bearer alksjdas239ld asdasd123lksadsj", false, false},
 	}


### PR DESCRIPTION
The `CheckAuthorization` middleware in Capsule proxy contains a regex which checks of the bearer token is a valid JWT token.
GCP uses an access token for authentication which does not pass this regex check.

Steps to reproduce:

1. Made myself tenant owner using my GCP username:
```apiVersion: capsule.clastix.io/v1beta1
kind: Tenant
metadata:
  name: my-tenant
spec:
  additionalRoleBindings:
  - clusterRoleName: cluster-admin
    subjects:
    - name: gitops-reconciler
      kind: ServiceAccount
      namespace: klarriofc000policy
  owners:
  - name: system:serviceaccount:my-tenant:gitops-reconciler
    kind: ServiceAccount
  - name: nvanrymenant
    kind: User
```
2. Create local forward to capsule-proxy service: ` kubectl port-forward service/capsule-proxy 9001:9001 -n capsule-system`
3. Obtain GKE credentials: `gcloud container clusters get-credentials dp-gke-test --zone europe-west1`
4. Obtain id token: `/usr/lib/google-cloud-sdk/bin/gcloud config config-helper --format=json`
5. Query the Kubernetes API via Capsule proxy:
```
curl -kv --header "Authorization: Bearer ya29.A0AVAxxxxxxx" 'https://localhost:9001/api/v1/namespaces/klarriofc000policy-nginx'
```
Without the fix this request fails and results in `HandleUnauthorized` handler to be called.
